### PR TITLE
Update runtime to 23.08, remove ImageMagick

### DIFF
--- a/com.github.reduz.ChibiTracker.yaml
+++ b/com.github.reduz.ChibiTracker.yaml
@@ -1,6 +1,6 @@
 app-id: com.github.reduz.ChibiTracker
 runtime: org.freedesktop.Platform
-runtime-version: '22.08'
+runtime-version: '23.08'
 sdk: org.freedesktop.Sdk
 command: chibitracker
 finish-args:
@@ -36,12 +36,14 @@ modules:
       - install -Dm644 com.github.reduz.ChibiTracker.metainfo.xml ${FLATPAK_DEST}/share/metainfo/com.github.reduz.ChibiTracker.metainfo.xml
       - install -Dm644 com.github.reduz.ChibiTracker.desktop ${FLATPAK_DEST}/share/applications/com.github.reduz.ChibiTracker.desktop
       - install -Dm644 program/cticon.png ${FLATPAK_DEST}/share/icons/hicolor/32x32/apps/com.github.reduz.ChibiTracker.png
-      - icon_in="program/cticon.png";
-        icon_out="com.github.reduz.ChibiTracker.png";
-        for s in {32,64,128,256,512}; do
-        convert "${icon_in}" -resize "${s}" "${icon_out}";
-        install -p -Dm644 "${icon_out}" -t "${FLATPAK_DEST}/share/icons/hicolor/${s}x${s}/apps/";
-        done;
+      - |
+        ICON_IN='program/cticon.png'
+        ICON_OUT='com.github.reduz.ChibiTracker.png'
+        for s in {32,64,128,256,512} ; do
+          SIZE="${s}x${s}"
+          ffmpeg -y -i "${ICON_IN}" -update 1 -s "${SIZE}" -sws_flags neighbor "${ICON_OUT}"
+          install -p -Dm644 "${ICON_OUT}" -t "${FLATPAK_DEST}/share/icons/hicolor/${SIZE}/apps/"
+        done
     sources:
       - type: git
         url: https://github.com/reduz/chibitracker.git
@@ -52,16 +54,3 @@ modules:
         path: com.github.reduz.ChibiTracker.desktop
       - type: file
         path: com.github.reduz.ChibiTracker.metainfo.xml
-    modules:
-      - name: ImageMagick
-        config-opts:
-          - --disable-static
-          - --disable-docs
-          - --with-hdri
-          - --with-pic
-        sources:
-          - type: archive
-            url: https://github.com/ImageMagick/ImageMagick/archive/7.0.8-65.tar.gz
-            sha256: 14afaf722d8964ed8de2ebd8184a229e521f1425e18e7274806f06e008bf9aa7
-        cleanup:
-          - '*'


### PR DESCRIPTION
This MR updates the runtime to `23.08`.
I didn't see any reference to ImageMagick in the ChibiTracker code so I replaced the use of `convert` with `ffmpeg`.
I also set it to upscale the icon using a nearest neighbour filter for the aesthetic.