### PR TITLE
Fix libdecor gtk plugin issue

### DIFF
--- a/com.github.reduz.ChibiTracker.yaml
+++ b/com.github.reduz.ChibiTracker.yaml
@@ -17,7 +17,7 @@ cleanup:
   - /lib/pkgconfig
   - /share/aclocal
 modules:
-  - shared-modules/SDL2/SDL2-with-libdecor.json
+  - shared-modules/libdecor/libdecor-0.2.0.json
   - shared-modules/SDL/sdl12-compat.json
   - name: scons
     buildsystem: simple


### PR DESCRIPTION
Fixes #6

- Remove SDL 2 explicit dependency (will use runtime version instead)
- Add dependency on libdecor 0.2.0 (will override version on runtime)